### PR TITLE
Avoid explicit any

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "height"
   ],
   "author": "Steve Papa <dev@stevepapa.com>",
-  "main": "angular2-autosize.js",
-  "typings": "./angular2-autosize.d.ts",
+  "main": "angular2-autosize.ts",
   "license": "MIT",
   "devDependencies": {
     "angular2": "2.0.0-beta.0",

--- a/src/autosize.directive.ts
+++ b/src/autosize.directive.ts
@@ -1,4 +1,4 @@
-import { ElementRef, HostListener, Directive} from 'angular2/core';
+import { ElementRef, HostListener, Directive} from '@angular/core';
 
 @Directive({
     selector: 'textarea[autosize]'
@@ -6,15 +6,15 @@ import { ElementRef, HostListener, Directive} from 'angular2/core';
 
 export class Autosize {
  @HostListener('input',['$event.target'])
-  onInput(textArea) {
+  onInput(textArea: HTMLTextAreaElement): void {
     this.adjust();
   }
   constructor(public element: ElementRef){
   }
-  ngOnInit(){
+  ngOnInit(): void{
     this.adjust();
   }
-  adjust(){
+  adjust(): void{
     this.element.nativeElement.style.overflow = 'hidden';
     this.element.nativeElement.style.height = 'auto';
     this.element.nativeElement.style.height = this.element.nativeElement.scrollHeight + "px";


### PR DESCRIPTION
In my project the TS compiler noImplicitAny flag is set to true. This made angular2-autosize fail to compile due to an implicit any on the onInput function parameter.

This small PR gives the parameter and return types explicit declarations.

Also updated the ng2 import statement to use the preferred syntax of @angular/core.

Also modified project.json - the typings file reference did not exist in the repo, and the 'main' file was a js file. I believe it should be the ts file since this module is distributed as TS source.
