### PR TITLE
ngOninit to ngAfterContentChecked

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "license": "MIT",
   "devDependencies": {
     "@angular": "2.0.0-beta.0",
-    "typescript": "^1.7.3",
+    "typescript": "^1.7.3"
   }
 }

--- a/src/autosize.directive.ts
+++ b/src/autosize.directive.ts
@@ -11,7 +11,7 @@ export class Autosize {
   }
   constructor(public element: ElementRef){
   }
-  ngOnInit(): void{
+  ngAfterContentChecked(): void{
     this.adjust();
   }
   adjust(): void{


### PR DESCRIPTION
Changed ngOninit to ngAfterContentChecked for already filled textareas.
Plus a package.json error fix.
