### PR TITLE
fix bug - page couldn't be scrolled to the end due to textarea heigh changes in ngAfterContentChecked

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import {Autosize} from 'angular2-autosize';
 
 @Component({
   template: `
-    <textarea autosize class="my-textarea">Hello, this is an example of Autosize in Angular2.</textarea>
+    <textarea [autosize]='myTextArea.value' class="my-textarea" #myTextArea>Hello, this is an example of Autosize in Angular2.</textarea>
   `,
   directives: [Autosize]
 })

--- a/src/autosize.directive.ts
+++ b/src/autosize.directive.ts
@@ -1,22 +1,25 @@
-import { ElementRef, HostListener, Directive} from '@angular/core';
+import { Directive, ElementRef, HostListener, Input, SimpleChange, Renderer } from '@angular/core';
 
 @Directive({
     selector: 'textarea[autosize]'
 })
-
 export class Autosize {
- @HostListener('input',['$event.target'])
-  onInput(textArea: HTMLTextAreaElement): void {
+  @Input() autosize: string;
+  
+  constructor(public renderer: Renderer, public element: ElementRef) {
+      this.renderer.setElementAttribute(this.element.nativeElement, 'rows', '1');
+  }
+
+  ngOnChanges(changes: {[key: string]: SimpleChange}) {
     this.adjust();
   }
-  constructor(public element: ElementRef){
-  }
-  ngAfterContentChecked(): void{
-    this.adjust();
-  }
+  
   adjust(): void{
-    this.element.nativeElement.style.overflow = 'hidden';
-    this.element.nativeElement.style.height = 'auto';
-    this.element.nativeElement.style.height = this.element.nativeElement.scrollHeight + "px";
+    this.renderer.setElementStyle(this.element.nativeElement, 'overflow', 'hidden');
+    this.renderer.setElementStyle(this.element.nativeElement, 'height', 'auto');
+    let scrollHeight = this.element.nativeElement.scrollHeight;
+    if(scrollHeight > 0) {
+      this.renderer.setElementStyle(this.element.nativeElement, 'height', scrollHeight + 'px');
+    }
   }
 }


### PR DESCRIPTION
page couldn't be scrolled to the end due to textarea heigh changes in ngAfterContentChecked, so using ngOnChanges. Adding rows as 1 to textarea in constructor
