### PR TITLE
Add index file

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from './angular2-autosize';


### PR DESCRIPTION
This avoids the need to import from `angular2-autosize/angular2-autosize` but instead just `angular2-autosize`.