### PR TITLE
Small adaptions fixing compiler warnings

### DIFF
--- a/angular2-autosize.ts
+++ b/angular2-autosize.ts
@@ -1,7 +1,7 @@
-import {Autosize} from './src/autosize.directive';
+import { Autosize } from './src/autosize.directive';
 
 export * from './src/autosize.directive';
 
 export default {
   directives: [Autosize]
-}
+};

--- a/src/autosize.directive.ts
+++ b/src/autosize.directive.ts
@@ -1,11 +1,11 @@
-import { ElementRef, HostListener, Directive} from '@angular/core';
+import { ElementRef, HostListener, Directive } from '@angular/core';
 
 @Directive({
     selector: 'textarea[autosize]'
 })
 
 export class Autosize {
- @HostListener('input',['$event.target'])
+ @HostListener('input', ['$event.target'])
   onInput(textArea: HTMLTextAreaElement): void {
     this.adjust();
   }
@@ -17,6 +17,6 @@ export class Autosize {
   adjust(): void{
     this.element.nativeElement.style.overflow = 'hidden';
     this.element.nativeElement.style.height = 'auto';
-    this.element.nativeElement.style.height = this.element.nativeElement.scrollHeight + "px";
+    this.element.nativeElement.style.height = this.element.nativeElement.scrollHeight + 'px';
   }
 }


### PR DESCRIPTION
Hope you are fine with it. Just stumbled upon this fairly small changes and changed them.

WARNING in ./~/angular2-autosize/angular2-autosize.ts
[7, 2]: Missing semicolon
[1, 8]: You need to leave whitespaces inside of the import statement's curly braces (https://goo.gl/25R7qr)

WARNING in ./~/angular2-autosize/src/autosize.directive.ts
[20, 89]: " should be '
[8, 24]: missing whitespace
[1, 8]: You need to leave whitespaces inside of the import statement's curly braces (https://goo.gl/25R7qr)